### PR TITLE
Use previous eye's base matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-needs/*
-openvr/*
-minitrace/*
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+needs/*
+openvr/*
+minitrace/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 needs/*
 openvr/*
 minitrace/*
-
+xivr/bin/*
+xivr/obj/*
+xivr_main/bin/*
+xivr_main/x64/*
+.vs/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ xivr/obj/*
 xivr_main/bin/*
 xivr_main/x64/*
 .vs/*
-trace.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 needs/*
 openvr/*
 minitrace/*
-xivr/bin/*
-xivr/obj/*
-xivr_main/bin/*
-xivr_main/x64/*
-.vs/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ xivr/obj/*
 xivr_main/bin/*
 xivr_main/x64/*
 .vs/*
+trace.json

--- a/xivr/xivr_hooks.cs
+++ b/xivr/xivr_hooks.cs
@@ -159,6 +159,7 @@ namespace xivr
         private bool doLocomotion = false;
         private int gameMode = 0;
         private int curEye = 0;
+        private int curFrame = 0;
         private int[] nextEye = { 1, 0 };
         private int[] swapEyes = { 1, 0 };
         private float RadianConversion = MathF.PI / 180.0f;
@@ -185,6 +186,7 @@ namespace xivr
 
 
         Matrix4x4 curViewMatrix = Matrix4x4.Identity;
+        Matrix4x4 prevFrameGameMatrix = Matrix4x4.Identity;
         Matrix4x4 hmdMatrix = Matrix4x4.Identity;
         Matrix4x4 lhcMatrix = Matrix4x4.Identity;
         Matrix4x4 rhcMatrix = Matrix4x4.Identity;
@@ -832,7 +834,17 @@ namespace xivr
                 else
                     hmdMatrix = hmdMatrix * eyeOffsetMatrix[curEye];
 
-                SafeMemory.Read<Matrix4x4>(gameViewMatrixAddr, out gameViewMatrix);
+                if (curFrame == 0)
+                {
+                    SafeMemory.Read<Matrix4x4>(gameViewMatrixAddr, out gameViewMatrix);
+                    prevFrameGameMatrix = gameViewMatrix;
+                    curFrame = 1;
+                }
+                else
+                {
+                    gameViewMatrix = prevFrameGameMatrix;
+                    curFrame = 0;
+                }
                 gameViewMatrix = gameViewMatrix * horizonLockMatrix * revOnward * hmdMatrix;
                 SafeMemory.Write<Matrix4x4>(gameViewMatrixAddr, gameViewMatrix);
             }


### PR DESCRIPTION
Experimental change that only fetches view matrix from the game on the first eye. For the second eye it will re-use that matrix, so in-game camera moves will not use two different offsets for each eye.

This experiment is not guaranteed to sync with the eyes, and will need a way to account for that.