### PR TITLE
Use previous frame base matrix for second eye

### DIFF
--- a/xivr/Configuration.cs
+++ b/xivr/Configuration.cs
@@ -25,6 +25,8 @@ namespace xivr
         public bool conloc { get; set; } = false;
         public bool swapEyes { get; set; } = false;
         public bool swapEyesUI { get; set; } = false;
+        public bool stereoHack { get; set; } = false;
+        public bool swapFrameCadence { get; set; } = false;
         public bool motioncontrol { get; set; } = true;
         public int hmdWidth { get; set; } = 0;
         public int hmdHeight { get; set; } = 0;

--- a/xivr/PluginUI.cs
+++ b/xivr/PluginUI.cs
@@ -94,6 +94,22 @@ namespace xivr
                     xivr.Plugin.doUpdate = true;
                 }
 
+                bool stereoHack = xivr.Configuration.stereoHack;
+                if (ImGui.Checkbox("Enable Stereo eyes hack", ref stereoHack))
+                {
+                    xivr.Configuration.stereoHack = stereoHack;
+                    xivr.Configuration.Save();
+                    xivr.Plugin.doUpdate = true;
+                }
+
+                bool swapFrameCadence = xivr.Configuration.swapFrameCadence;
+                if (ImGui.Checkbox("Swap stereo hack cadence", ref swapFrameCadence))
+                {
+                    xivr.Configuration.swapFrameCadence = swapFrameCadence;
+                    xivr.Configuration.Save();
+                    xivr.Plugin.doUpdate = true;
+                }
+
                 if (ImGui.Button("Recenter"))
                 {
                     xivr.Configuration.runRecenter = false;

--- a/xivr/xivr.cs
+++ b/xivr/xivr.cs
@@ -281,7 +281,8 @@ namespace xivr
 
                 xivr_hooks.ForceFloatingScreen(forceFloating);
                 xivr_hooks.SetLocks(Configuration.horizontalLock, Configuration.verticalLock, Configuration.horizonLock);
-                
+                xivr_hooks.SetStereoHacks(Configuration.stereoHack, Configuration.swapFrameCadence);
+
                 if (Configuration.isEnabled == true && isEnabled == false)
                 {
                     //----

--- a/xivr/xivr_hooks.cs
+++ b/xivr/xivr_hooks.cs
@@ -845,18 +845,23 @@ namespace xivr
                 if (swapFrameCadence)
                     frameCadence = swapEyes[curEye];
 
-                if (frameCadence == 0 || prevFrameGameMatrix == Matrix4x4.Identity)
+                if(stereoHack)
                 {
-                    SafeMemory.Read<Matrix4x4>(gameViewMatrixAddr, out gameViewMatrix);
-                    prevFrameGameMatrix = gameViewMatrix;
+                    if (frameCadence == 0 || prevFrameGameMatrix == Matrix4x4.Identity)
+                    {
+                        SafeMemory.Read<Matrix4x4>(gameViewMatrixAddr, out gameViewMatrix);
+                        prevFrameGameMatrix = gameViewMatrix;
+                    }
+                    else
+                    {
+                        gameViewMatrix = prevFrameGameMatrix;
+                    }
                 }
                 else
                 {
-                    if (stereoHack)
-                        gameViewMatrix = prevFrameGameMatrix;
-                    else
-                        SafeMemory.Read<Matrix4x4>(gameViewMatrixAddr, out gameViewMatrix);
+                    SafeMemory.Read<Matrix4x4>(gameViewMatrixAddr, out gameViewMatrix);
                 }
+                
                 gameViewMatrix = gameViewMatrix * horizonLockMatrix * revOnward * hmdMatrix;
                 SafeMemory.Write<Matrix4x4>(gameViewMatrixAddr, gameViewMatrix);
             }


### PR DESCRIPTION
Second version of the stereo eye hack. This will add checkbox in the UI for quick A/B testing. Also supports swap frame cadence in case the default cadence starts the wrong eye and straddles the VR frames.

Steps to produce the effect:
1. Reduce headset hz as much as possible. 60hz is best and most visible.
2. Disable horizontal snap turning
3. Disable stereo hack to ensure your seeing the baseline
4. Move to Inn where framerate is steady
5. Increase camera sensitivity in options for faster camera
6. Swing camera around character as fast as possible
7. You may observe your character "shrink" in one direction or "grow" in another direction. For me this comes with some eye strain.
8. Optionally, reproduce these steps in a busy area where frametimes are missed. The effect is exaggerated here.

Once you've spotted the "shrink" and "grow" effect, now enable the Hack in the menu. You may have to fiddle with frame cadence swap. If the cadence is wrong you'll see big eye strain and extreme shrink/grow effect.

