### PR TITLE
Adding ipd setting

### DIFF
--- a/xivr/Configuration.cs
+++ b/xivr/Configuration.cs
@@ -22,6 +22,7 @@ namespace xivr
         public float snapRotateAmountY { get; set; } = 15.0f;
         public float uiOffsetZ { get; set; } = 0.0f;
         public float uiOffsetScale { get; set; } = 1.0f;
+        public float ipdOffset { get; set; } = 0.0f;
         public bool conloc { get; set; } = false;
         public bool swapEyes { get; set; } = false;
         public bool swapEyesUI { get; set; } = false;

--- a/xivr/xivr.cs
+++ b/xivr/xivr.cs
@@ -208,6 +208,14 @@ namespace xivr
                         doUpdate = true;
                         break;
                     }
+                case "ipd":
+                    {
+                        float.TryParse(regex.Groups[2].Value, out var amount);
+                        Configuration.ipdOffset = amount;
+                        Configuration.Save();
+                        LoadSettings();
+                        break;
+                    }
                 case "conloc":
                     {
                         Configuration.conloc = !Configuration.conloc;
@@ -247,6 +255,7 @@ namespace xivr
             xivr_hooks.SetConLoc(Configuration.conloc);
             xivr_hooks.DoSwapEyes(Configuration.swapEyes);
             xivr_hooks.DoSwapEyesUI(Configuration.swapEyesUI);
+            xivr_hooks.SetIPDOffset(Configuration.ipdOffset);
             xivr_hooks.UpdateZScale(Configuration.uiOffsetZ, Configuration.uiOffsetScale);
         }
 

--- a/xivr/xivr_hooks.cs
+++ b/xivr/xivr_hooks.cs
@@ -164,6 +164,7 @@ namespace xivr
         private float RadianConversion = MathF.PI / 180.0f;
         private float cameraZoom = 0.0f;
         private float leftBumperValue = 0.0f;
+        private float ipdOffset = 0.0f;
         private Vector2 rotateAmount = new Vector2(0.0f, 0.0f);
         private Vector2 offsetAmount = new Vector2(0.0f, 0.0f);
         private Vector3 onwardAngle = new Vector3(0.0f, 0.0f, 0.0f);
@@ -439,6 +440,11 @@ namespace xivr
         {
             if (x != 0) snapRotateAmount.X = (x * RadianConversion);
             if (x != 0) snapRotateAmount.Y = (y * RadianConversion);
+        }
+
+        public void SetIPDOffset(float ipd)
+        {
+            ipdOffset = (ipd / 1000.0f) * -1;
         }
 
         public void SetConLoc(bool conloc)
@@ -806,6 +812,7 @@ namespace xivr
             {
                 Matrix4x4 gameViewMatrix = new Matrix4x4();
                 Matrix4x4 horizonLockMatrix = Matrix4x4.Identity;
+                Matrix4x4 ipdMatrix = Matrix4x4.Identity;
                 if (camInst != null && horizonLock)
                 {
                     GameCamera* gameCamera = (GameCamera*)(camInst->CameraOffset + (camInst->CameraIndex * 8));
@@ -827,10 +834,14 @@ namespace xivr
                 if (doLocomotion == false || gameMode == 1)
                     revOnward = Matrix4x4.Identity;
 
+                int eye = curEye;
                 if (doSwapEye)
-                    hmdMatrix = hmdMatrix * eyeOffsetMatrix[swapEyes[curEye]];
-                else
-                    hmdMatrix = hmdMatrix * eyeOffsetMatrix[curEye];
+                    eye = swapEyes[curEye];
+
+                if (eye == 0) ipdMatrix.M41 = ipdOffset;
+                else ipdMatrix.M41 = -ipdOffset;
+
+                hmdMatrix = hmdMatrix * ipdMatrix * eyeOffsetMatrix[eye];
 
                 SafeMemory.Read<Matrix4x4>(gameViewMatrixAddr, out gameViewMatrix);
                 gameViewMatrix = gameViewMatrix * horizonLockMatrix * revOnward * hmdMatrix;


### PR DESCRIPTION
Adding /xivr ipd command.
Positive offsets make your IPD wider. Negative offets make your IPD lower. Try ranges -5 to 5 to experiment with to get a feel for it.

The advantage of having an in game ipd setting separate from SteamVR's world size override is that SteamVR's world size override also changes the player's virtual height. This had the problem of making you "shorter" if the world appeared too small and you used Steam's setting to make the world larger. This lets you make the world appear a size that is "more correct" to the eye will maintaining player's virtual height.