### PR TITLE
WaitGetPoses after compositor submit

### DIFF
--- a/xivr/xivr_hooks.cs
+++ b/xivr/xivr_hooks.cs
@@ -54,8 +54,9 @@ namespace xivr
         Projection = 0,
         EyeOffset = 1,
         hmdPosition = 10,
-        LeftHand = 20,
-        RightHand = 30,
+        prevHmdPosition = 20,
+        LeftHand = 30,
+        RightHand = 40,
     }
 
     internal unsafe class xivr_hooks
@@ -407,7 +408,6 @@ namespace xivr
                 }
 
                 curEye = nextEye[curEye];
-                SetFramePose();
             }
         }
 

--- a/xivr_main/dllmain.cpp
+++ b/xivr_main/dllmain.cpp
@@ -407,7 +407,19 @@ __declspec(dllexport) void RenderUI(bool enableVR, bool enableFloatingHUD)
 		if (enableVR)
 		{
 			projectionMatrix = (DirectX::XMMATRIX)(svr.GetFramePose(poseType::Projection, curEyeView)._m);
-			viewMatrix = (DirectX::XMMATRIX)(svr.GetFramePose(poseType::EyeOffset, curEyeView)._m) * (DirectX::XMMATRIX)(svr.GetFramePose(poseType::hmdPosition, curEyeView)._m);
+
+			uMatrix hmdMatrix;
+
+			if (threadedEye == 0)
+			{
+				hmdMatrix = svr.GetFramePose(poseType::prevHmdPosition, curEyeView);
+			}
+			else
+			{
+				hmdMatrix = svr.GetFramePose(poseType::hmdPosition, curEyeView);
+			}
+		
+			viewMatrix = (DirectX::XMMATRIX)(svr.GetFramePose(poseType::EyeOffset, curEyeView)._m) * (DirectX::XMMATRIX)(hmdMatrix._m);
 			viewMatrix = DirectX::XMMatrixTranspose(viewMatrix);
 			viewMatrix = DirectX::XMMatrixInverse(0, viewMatrix);
 

--- a/xivr_main/simpleVR.cpp
+++ b/xivr_main/simpleVR.cpp
@@ -31,6 +31,7 @@ void simpleVR::InitalizeVR()
 	memcpy(&eyeViewMatrixRaw[1], identMatrix._m, sizeof(uMatrix));
 	memcpy(&eyeViewMatrixRaw[2], identMatrix._m, sizeof(uMatrix));
 	memcpy(&hmdMatrix, identMatrix._m, sizeof(uMatrix));
+	memcpy(&prevHmdMatrix, identMatrix._m, sizeof(uMatrix));
 	memcpy(&controllerLeftMatrix, identMatrix._m, sizeof(uMatrix));
 	memcpy(&controllerRightMatrix, identMatrix._m, sizeof(uMatrix));
 
@@ -160,8 +161,8 @@ void simpleVR::SetFramePose()
 		static int rContNum = 0;
 
 		vr::ETrackingUniverseOrigin universeOrigin = vr::VRCompositor()->GetTrackingSpace();
-		//vr::VRCompositor()->WaitGetPoses(rTrackedDevicePose, vr::k_unMaxTrackedDeviceCount, NULL, 0);
-		vr::VRCompositor()->GetLastPoses(rTrackedDevicePose, vr::k_unMaxTrackedDeviceCount, NULL, 0);
+		vr::VRCompositor()->WaitGetPoses(rTrackedDevicePose, vr::k_unMaxTrackedDeviceCount, NULL, 0);
+		//vr::VRCompositor()->GetLastPoses(rTrackedDevicePose, vr::k_unMaxTrackedDeviceCount, NULL, 0);
 
 		vr::TrackedDevicePose_t hmdPose = vr::TrackedDevicePose_t();
 		vr::TrackedDevicePose_t controllerPose[2] = { 0, 0 };
@@ -244,6 +245,7 @@ void simpleVR::SetFramePose()
 				matPose.m[0][2], matPose.m[1][2], matPose.m[2][2], 0.0f,
 				matPose.m[0][3], matPose.m[1][3], matPose.m[2][3], 1.0f
 			};
+			memcpy(prevHmdMatrix.matrix, hmdMatrix.matrix, sizeof(float) * 4 * 4);
 			memcpy(hmdMatrix.matrix, hMatrix, sizeof(float) * 4 * 4);
 		}
 
@@ -292,6 +294,9 @@ uMatrix simpleVR::GetFramePose(poseType pose_type, int eye)
 	case poseType::hmdPosition:
 		return hmdMatrix;
 		break;
+	case poseType::prevHmdPosition:
+		return prevHmdMatrix;
+		break;
 	case poseType::LeftHand:
 		return controllerLeftMatrix;
 		break;
@@ -319,17 +324,17 @@ void simpleVR::Render(ID3D11Texture2D* leftEye, ID3D11Texture2D* rightEye)
 		vr::VRTextureBounds_t _leftbound = { 0.0f, 0.0f,  0.5f, 1.0f };
 		vr::VRTextureBounds_t _rightbound = { 0.5f, 0.0f,  1.0f, 1.0f };
 
-		vr::VRCompositor()->WaitGetPoses(rTrackedDevicePose, vr::k_unMaxTrackedDeviceCount, NULL, 0);
-
 		vr::EVRCompositorError error = vr::VRCompositorError_None;
 		error = vr::VRCompositor()->Submit(vr::Eye_Left, &completeTexture[0], &_bound, vr::Submit_Default);
 		if (error) {
 			int a = 1;
 		}
-
+	
 		error = vr::VRCompositor()->Submit(vr::Eye_Right, &completeTexture[1], &_bound, vr::Submit_Default);
 		if (error) {
 			int a = 1;
 		}
+
+		SetFramePose();
 	}
 }

--- a/xivr_main/simpleVR.h
+++ b/xivr_main/simpleVR.h
@@ -23,6 +23,7 @@ class simpleVR
 	uMatrix eyeViewMatrixRaw[3];
 	uMatrix identMatrix;
 	uMatrix hmdMatrix;
+	uMatrix prevHmdMatrix;
 	uMatrix controllerLeftMatrix;
 	uMatrix controllerRightMatrix;
 	uMatrix genericMatrix[3];

--- a/xivr_main/stCommon.h
+++ b/xivr_main/stCommon.h
@@ -12,8 +12,9 @@ enum poseType
 	Projection = 0,
 	EyeOffset = 1,
 	hmdPosition = 10,
-	LeftHand = 20,
-	RightHand = 30,
+	prevHmdPosition = 20,
+	LeftHand = 30,
+	RightHand = 40,
 };
 
 struct stScreenLayout


### PR DESCRIPTION
Moving WaitGetPoses to after vr compositor submit. Now using the poses from WaitGetPoses instead of GetLastPoses

Headset pose prediction is now 1 frame out of step instead of 2. I tried to get it to 0 but had trouble.

Unsolved: I don't understand whats happening fully with the frame rendering yet. I could only get the UI eyes to agree by using the previous frame's head pose. This syncs it with the world matrix, strangely. It's a tease of whats possible because if I always use poseType::hmdPosition for both threadedEye 0 and 1, then eye 0 has the absolute best pose, and is lockstep with gaurdian. Super ideal. But I cant crack this for the game render or other UI Eye render yet.