### PR TITLE
Make the IPD slider easier to use

### DIFF
--- a/xivr/PluginUI.cs
+++ b/xivr/PluginUI.cs
@@ -129,7 +129,7 @@ namespace xivr
 
             ImGui.Text("Z Offset"); ImGui.SameLine(); ImGui.InputFloat("##DrawUISetings:zoff", ref uiOffsetZ);
             ImGui.Text("Z Scale"); ImGui.SameLine(); ImGui.InputFloat("##DrawUISetings:zscale", ref uiOffsetScale);
-            ImGui.Text("IPD Offset"); ImGui.SameLine(); ImGui.SliderFloat("##DrawUISetings:ipdoff", ref ipdOffset, -1, 1, "%f");
+            ImGui.Text("IPD Offset"); ImGui.SameLine(); ImGui.SliderFloat("##DrawUISetings:ipdoff", ref ipdOffset, -10, 10, "%f");
 
             ImGui.Text("Swap Eyes"); ImGui.SameLine(); ImGui.Checkbox("##DrawUISetings:swapeyes", ref swapEyes);
             ImGui.Text("Swap Eyes UI"); ImGui.SameLine(); ImGui.Checkbox("##DrawUISetings:swapeyesui", ref swapEyesUI);

--- a/xivr_main/simpleVR.cpp
+++ b/xivr_main/simpleVR.cpp
@@ -347,6 +347,6 @@ void simpleVR::MakeIPDOffset()
 	memcpy(&eyeViewMatrix[0], &eyeViewMatrixRaw[0], sizeof(uMatrix));
 	memcpy(&eyeViewMatrix[1], &eyeViewMatrixRaw[1], sizeof(uMatrix));
 
-	eyeViewMatrix[0]._m[12] += -cfg->ipdOffset;
-	eyeViewMatrix[1]._m[12] += +cfg->ipdOffset;
+	eyeViewMatrix[0]._m[12] += -(cfg->ipdOffset / 1000);
+	eyeViewMatrix[1]._m[12] += +(cfg->ipdOffset / 1000);
 }


### PR DESCRIPTION
The scale of IPD adjustments are at the 1/1000. Give players a simple -10 to 10 range, and then divide their setting by 1000.